### PR TITLE
Add UTF-8 to script

### DIFF
--- a/spheader.py
+++ b/spheader.py
@@ -23,7 +23,7 @@ def main():
         print(f"{jam_filename} not found.")
         return
 
-    with codecs.open(jam_filename, "r", encoding="shift-jis") as jam_file:
+    with codecs.open(jam_filename, "r", encoding="shift-jis" or "utf-8") as jam_file:
         jam_contents = jam_file.read()
 
         sp_size_match = re.search(r'SPsize\s*=\s*([\d,]+)', jam_contents)


### PR DESCRIPTION
The jam descriptors in the Appli Archives files uses plain ASCII for the app name.
So, if the script founds I'm the "AppName" field a UTF8 formated text, it spits an error.
This PR fixes this